### PR TITLE
Failing close if we have a non existent FQDN

### DIFF
--- a/api/v1alpha1/fqdnnetworkpolicy_testing.go
+++ b/api/v1alpha1/fqdnnetworkpolicy_testing.go
@@ -70,6 +70,10 @@ func (r *FQDNNetworkPolicy) GetValidNoProtocolResource() *FQDNNetworkPolicy {
 	return r.LoadResource("./config/samples/networking_v1alpha1_fqdnnetworkpolicy_valid_noprotocol.yaml")
 }
 
+func (r *FQDNNetworkPolicy) GetValidNonExistentFQDNResource() *FQDNNetworkPolicy {
+	return r.LoadResource("./config/samples/networking_v1alpha1_fqdnnetworkpolicy_valid_nonexistentfqdn.yaml")
+}
+
 func (r *FQDNNetworkPolicy) GetInvalidResource() *FQDNNetworkPolicy {
 	return r.LoadResource("./config/samples/networking_v1alpha1_fqdnnetworkpolicy_invalid.yaml")
 }

--- a/config/samples/networking_v1alpha1_fqdnnetworkpolicy_valid_nonexistentfqdn.yaml
+++ b/config/samples/networking_v1alpha1_fqdnnetworkpolicy_valid_nonexistentfqdn.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.gke.io/v1alpha1
+kind: FQDNNetworkPolicy
+metadata:
+  name: fqdnnetworkpolicy-valid-brokenfqdn
+spec:
+  podSelector: {}
+  egress:
+    - to:
+      - fqdns:
+        - foo.bar.notld
+      ports:
+      - port: 443
+        protocol: TCP

--- a/controllers/fqdnnetworkpolicy_controller.go
+++ b/controllers/fqdnnetworkpolicy_controller.go
@@ -329,6 +329,15 @@ func (r *FQDNNetworkPolicyReconciler) getNetworkPolicyEgressRules(ctx context.Co
 			}
 		}
 
+		if len(peers) == 0 {
+			// If no peers have been found (most likely because the provided
+			// FQDNs don't resolve to anything), then we don't create an egress
+			// rule at all to fail close. If we create one with only a "ports"
+			// section, but no "to" section, we're failing open.
+			log.Info("No peers found, skipping egress rule.")
+			continue
+		}
+
 		rules = append(rules, networking.NetworkPolicyEgressRule{
 			Ports: frule.Ports,
 			To:    peers,


### PR DESCRIPTION
Fix for issue 178002326.

To be able to fail close, I use the 127.0.0.0/8 CIDR as the CIDR block if the FQDN doesn't resolve.