### PR TITLE
Fix test for Egress only policy

### DIFF
--- a/config/samples/networking_v1alpha2_fqdnnetworkpolicy_valid.yaml
+++ b/config/samples/networking_v1alpha2_fqdnnetworkpolicy_valid.yaml
@@ -18,7 +18,8 @@ metadata:
   name: fqdnnetworkpolicy-valid
 spec:
   podSelector: {}
-  policyType: Egress
+  policyTypes:
+  - Egress
   egress:
     - to:
       - fqdns:

--- a/controllers/fqdnnetworkpolicy_controller_test.go
+++ b/controllers/fqdnnetworkpolicy_controller_test.go
@@ -123,6 +123,11 @@ var _ = Describe("FQDNNetworkPolicy controller", func() {
 					if err != nil {
 						return err
 					}
+					if len(networkPolicy.Spec.PolicyTypes) != 1 ||
+						networkPolicy.Spec.PolicyTypes[0] != networking.PolicyTypeEgress {
+						return errors.New("Unexpected PolicyType: " + fmt.Sprintf("%v", networkPolicy.Spec.PolicyTypes) +
+							". Expected PolicyType: [Egress]")
+					}
 					total := 0
 					for _, egressRule := range networkPolicy.Spec.Egress {
 						// checking that every CIDR in the NetworkPolicy


### PR DESCRIPTION
One of our test case was using the following test FQDNNetworkpolicy:

```
apiVersion: networking.gke.io/v1alpha2
kind: FQDNNetworkPolicy
metadata:
  name: fqdnnetworkpolicy-valid
spec:
  podSelector: {}
  policyType: Egress
  egress:
    - to:
      - fqdns:
        - github.com
        - gitlab.com
      ports:
      - port: 443
        protocol: TCP
```

The section `policyType: Egress` is not valid and was ignored.
It should be:

``` 
policyTypes:
- Egress
```

I've fixed this mistake, and updated the unit test to make sure that we check the policyTypes on this example.

Fix #16 