### PR TITLE
allow skiping ipv6 lookup by adding aaaa-lookups annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ By default, the NetworkPolicy associated with a FQDNNetworkPolicy gets deleted w
 To prevent this behavior, set the `fqdnnetworkpolicies.networking.gke.io/delete-policy` annotation to `abandon` on the
 NetworkPolicy.
 
-There might be scenarios where IPv6 AAAA lookups are not desired or supported in the resulting NetworkPolicy. 
-To skip AAAA lookups set the `fqdnnetworkpolicies.networking.gke.io/aaaa-lookups` annotation to `skip`
+You can disable AAAA lookups for an FQDNNetworkPolicy by setting the `fqdnnetworkpolicies.networking.gke.io/aaaa-lookups` annotation to `skip`. The resulting NetworkPolicy will not contain any IPv6 addresses.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To prevent this behavior, set the `fqdnnetworkpolicies.networking.gke.io/delete-
 NetworkPolicy.
 
 There might be scenarios where IPv6 AAAA lookups are not desired or supported in the resulting NetworkPolicy. 
-To skip AAAA loopups set the `fqdnnetworkpolicies.networking.gke.io/aaaa-lookups` annotation to `skip`
+To skip AAAA lookups set the `fqdnnetworkpolicies.networking.gke.io/aaaa-lookups` annotation to `skip`
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ By default, the NetworkPolicy associated with a FQDNNetworkPolicy gets deleted w
 To prevent this behavior, set the `fqdnnetworkpolicies.networking.gke.io/delete-policy` annotation to `abandon` on the
 NetworkPolicy.
 
+There might be scenarios where IPv6 AAAA lookups are not desired or supported in the resulting NetworkPolicy. 
+To skip AAAA loopups set the `fqdnnetworkpolicies.networking.gke.io/aaaa-lookups` annotation to `skip`
+
 ## Limitations
 
 There are a few functional limitations to FQDNNetworkPolicies:

--- a/api/v1alpha3/fqdnnetworkpolicy_testing.go
+++ b/api/v1alpha3/fqdnnetworkpolicy_testing.go
@@ -65,6 +65,10 @@ func (r *FQDNNetworkPolicy) GetValidNonExistentFQDNResource() *FQDNNetworkPolicy
 	return r.LoadResource("./config/samples/networking_v1alpha3_fqdnnetworkpolicy_valid_nonexistentfqdn.yaml")
 }
 
+func (r *FQDNNetworkPolicy) GetValidAaaaLookupsSkippedResource() *FQDNNetworkPolicy {
+	return r.LoadResource("./config/samples/networking_v1alpha3_fqdnnetworkpolicy_valid_aaaalookupsskipped.yaml")
+}
+
 func (r *FQDNNetworkPolicy) GetInvalidResource() *FQDNNetworkPolicy {
 	return r.LoadResource("./config/samples/networking_v1alpha3_fqdnnetworkpolicy_invalid.yaml")
 }

--- a/config/samples/networking_v1alpha3_fqdnnetworkpolicy_valid_aaaalookupsskipped.yaml
+++ b/config/samples/networking_v1alpha3_fqdnnetworkpolicy_valid_aaaalookupsskipped.yaml
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.gke.io/v1alpha3
+kind: FQDNNetworkPolicy
+metadata:
+  name: fqdnnetworkpolicy-valid
+  annotations:
+    fqdnnetworkpolicies.networking.gke.io/aaaa-lookups: "skip"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+    - to:
+      - fqdns:
+        - github.com
+        - gitlab.com
+      ports:
+      - port: 443
+        protocol: TCP

--- a/controllers/fqdnnetworkpolicy_controller.go
+++ b/controllers/fqdnnetworkpolicy_controller.go
@@ -45,7 +45,7 @@ type FQDNNetworkPolicyReconciler struct {
 var (
 	ownerAnnotation        = "fqdnnetworkpolicies.networking.gke.io/owned-by"
 	deletePolicyAnnotation = "fqdnnetworkpolicies.networking.gke.io/delete-policy"
-	AaaaLookupsAnnotation  = "fqdnnetworkpolicies.networking.gke.io/aaaa-lookups"
+	aaaaLookupsAnnotation  = "fqdnnetworkpolicies.networking.gke.io/aaaa-lookups"
 	finalizerName          = "finalizer.fqdnnetworkpolicies.networking.gke.io"
 	// TODO make retry configurable
 	retry = time.Second * time.Duration(10)
@@ -467,7 +467,7 @@ func (r *FQDNNetworkPolicyReconciler) getNetworkPolicyEgressRules(ctx context.Co
 					}
 				}
 				// check for AAAA lookups skip annotation
-				if fqdnNetworkPolicy.Annotations[AaaaLookupsAnnotation] == "skip" {
+				if fqdnNetworkPolicy.Annotations[aaaaLookupsAnnotation] == "skip" {
 					log.Info("FQDNNetworkPolicy has AAAA lookups policy set to skip, not resolving AAAA records")
 				} else {
 					// AAAA records

--- a/controllers/fqdnnetworkpolicy_controller.go
+++ b/controllers/fqdnnetworkpolicy_controller.go
@@ -466,8 +466,9 @@ func (r *FQDNNetworkPolicyReconciler) getNetworkPolicyEgressRules(ctx context.Co
 						}
 					}
 				}
+				// check for AAAA lookups skip annotation
 				if fqdnNetworkPolicy.Annotations[AaaaLookupsAnnotation] == "skip" {
-					log.Info("NetworkPolicy has AAAA lookups policy set to skip, not resolving AAAA records")
+					log.Info("FQDNNetworkPolicy has AAAA lookups policy set to skip, not resolving AAAA records")
 				} else {
 					// AAAA records
 					m6 := new(dns.Msg)


### PR DESCRIPTION
Hi Théo,

as suggested in [issue #24](https://github.com/GoogleCloudPlatform/gke-fqdnnetworkpolicies-golang/issues/24) , here's the adapted code, basically just introducing a check whether the annotation `fqdnnetworkpolicies.networking.gke.io/aaaa-lookups` is set to `skip` in the FQDNNetworkPolicy.

I tested this locally with following manifest:

```yaml
apiVersion: networking.gke.io/v1alpha3
kind: FQDNNetworkPolicy
metadata:
  name: allow-test
  namespace: test1
  annotations:
    fqdnnetworkpolicies.networking.gke.io/aaaa-lookups: "skip"
spec:
  podSelector: {}
  egress:
    - to:
      - fqdns:
        - heise.de # resolves to 193.99.144.80 (A) and 2a02:2e0:3fe:1001:302:: (AAAA)
      ports:
      - port: 443
        protocol: TCP
```

Both scenarios, with and without the `fqdnnetworkpolicies.networking.gke.io/aaaa-lookups` annotation, the code produces the expected NetworkPolicy.

I have to admit, I haven't added a test - if that is strictly required, please let me know. 
Please, feel free to adapt to your naming schema or coding guidelines.

Thanks a lot
Karsten