### PR TITLE
Bump Go to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/v1alpha3/groupversion_info.go
+++ b/api/v1alpha3/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha3 contains API Schema definitions for the networking v1alpha3 API group
-//+kubebuilder:object:generate=true
-//+groupName=networking.gke.io
+// +kubebuilder:object:generate=true
+// +groupName=networking.gke.io
 package v1alpha3
 
 import (

--- a/cloudbuild-tag.yaml
+++ b/cloudbuild-tag.yaml
@@ -14,23 +14,23 @@
 
 steps:
 - id: 'Install kubebuilder'
-  name: 'golang:1.18'
+  name: 'golang:1.20'
   args: ['/bin/sh', './tests/install-kubebuilder.sh']
   waitFor: ['-']
 - id: 'go mod download'
-  name: 'golang:1.18'
+  name: 'golang:1.20'
   args: ['go', 'mod', 'download']
   waitFor: ['Install kubebuilder']
 - id: 'go test'
-  name: 'golang:1.18'
+  name: 'golang:1.20'
   args: ['go', 'test', './...', '-coverprofile', 'cover.out']
   waitFor: ['go mod download', 'Install kubebuilder']
 - id: 'go vet'
-  name: 'golang:1.18'
+  name: 'golang:1.20'
   args: ['go', 'vet', './...']
   waitFor: ['go mod download', 'Install kubebuilder']
 - id: 'go fmt'
-  name: 'golang:1.18'
+  name: 'golang:1.20'
   args: ['/bin/sh', '-c', '[ -z $(gofmt -l ./) ]']
   waitFor: ['go mod download', 'Install kubebuilder']
 - id: 'Build and push image'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,23 +14,23 @@
 
 steps:
 - id: 'Install kubebuilder'
-  name: 'golang:1.18'
+  name: 'golang:1.20'
   args: ['/bin/sh', './tests/install-kubebuilder.sh']
   waitFor: ['-']
 - id: 'go mod download'
-  name: 'golang:1.18'
+  name: 'golang:1.20'
   args: ['go', 'mod', 'download']
   waitFor: ['Install kubebuilder']
 - id: 'go test'
-  name: 'golang:1.18'
+  name: 'golang:1.20'
   args: ['go', 'test', './...', '-coverprofile', 'cover.out']
   waitFor: ['go mod download', 'Install kubebuilder']
 - id: 'go vet'
-  name: 'golang:1.18'
+  name: 'golang:1.20'
   args: ['go', 'vet', './...']
   waitFor: ['go mod download', 'Install kubebuilder']
 - id: 'go fmt'
-  name: 'golang:1.18'
+  name: 'golang:1.20'
   args: ['/bin/sh', '-c', '[ -z $(gofmt -l ./) ]']
   waitFor: ['go mod download', 'Install kubebuilder']
 options:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,10 +29,6 @@ steps:
   name: 'golang:1.20'
   args: ['go', 'vet', './...']
   waitFor: ['go mod download', 'Install kubebuilder']
-- id: 'go fmt debug'
-  name: 'golang:1.20'
-  args: ['gofmt', '-l', './']
-  waitFor: ['go mod download', 'Install kubebuilder']
 - id: 'go fmt'
   name: 'golang:1.20'
   args: ['/bin/sh', '-c', '[ -z $(gofmt -l ./) ]']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,6 +29,10 @@ steps:
   name: 'golang:1.20'
   args: ['go', 'vet', './...']
   waitFor: ['go mod download', 'Install kubebuilder']
+- id: 'go fmt debug'
+  name: 'golang:1.20'
+  args: ['gofmt', '-l', './']
+  waitFor: ['go mod download', 'Install kubebuilder']
 - id: 'go fmt'
   name: 'golang:1.20'
   args: ['/bin/sh', '-c', '[ -z $(gofmt -l ./) ]']

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,16 @@ module github.com/GoogleCloudPlatform/gke-fqdnnetworkpolicies-golang
 go 1.20
 
 require (
+	github.com/go-logr/logr v1.2.0
+	github.com/miekg/dns v1.1.50
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/client-go v0.24.0
 	sigs.k8s.io/controller-runtime v0.12.1
-)
-
-require (
-	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
-	golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -34,7 +32,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/go-logr/logr v1.2.0
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
@@ -51,7 +48,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
-	github.com/miekg/dns v1.1.50
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -66,12 +62,14 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
-	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
+	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
+	golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
@@ -86,5 +84,4 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/gke-fqdnnetworkpolicies-golang
 
-go 1.18
+go 1.20
 
 require (
 	github.com/onsi/ginkgo v1.16.5
@@ -34,7 +34,7 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/go-logr/logr v1.2.0
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
@@ -66,7 +66,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
-	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
@@ -86,5 +86,5 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
+	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -637,6 +637,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
## Bump Go to 1.20:

- Dockerfile
- Cloudbuild files
- Deps (move two parts direct and indirect but no change versions)

## Additional note

Prepare the dependencies to be cleaned and upgraded.